### PR TITLE
debootstrap: Install and configure rng-tools.

### DIFF
--- a/olinux/create_arm_debootstrap.sh
+++ b/olinux/create_arm_debootstrap.sh
@@ -160,6 +160,10 @@ chroot_deb $TARGET_DIR 'chgrp mail /var/mail/'
 chroot_deb $TARGET_DIR 'chmod g+w /var/mail/'
 chroot_deb $TARGET_DIR 'chmod g+s /var/mail/'
 
+# Install rng (Random Number Generator) to gain enough entropy for SSL,GPG key generation
+chroot_deb $TARGET_DIR "apt-get install -y --force-yes rng-tools"
+echo 'HRNGDEVICE=/dev/urandom' >> $TARGET_DIR/etc/default/rng-tools
+
 # Set hostname
 echo $DEB_HOSTNAME > $TARGET_DIR/etc/hostname
 


### PR DESCRIPTION
Install rng-tools to gain enough entropy for SSL/GPG keys generation.

I have the same « problem » on my olinux (but it's quite normal… fresh install, nothing running, …)

``` shell
root@olinux:~# cat /proc/sys/kernel/random/entropy_avail
102
root@olinux:~# service rng-tools start
Stopping Hardware RNG entropy gatherer daemon: (not running).
Starting Hardware RNG entropy gatherer daemon: rngd.
root@olinux:~# cat /proc/sys/kernel/random/entropy_avail
2103
```

Closes: #11
